### PR TITLE
`reader`: add opt-in chunked string sink for SAX handlers

### DIFF
--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -954,6 +954,41 @@ private:
         SizeType length_;
     };
 
+    // Detects whether Handler opts in to receiving string values through a
+    // handler-provided sink instead of the reader's contiguous stack, which
+    // avoids a large contiguous allocation for very large string values.
+    // An opting-in Handler must provide:
+    //   typedef ... ChunkedStringSinkType;      // output stream: Put(Ch), GetLength()
+    //   bool AcceptsChunkedString() const;      // dynamic, per-value opt-in
+    //   ChunkedStringSinkType& ChunkedStringSink(); // returns an empty sink
+    //   bool ChunkedString(SizeType length);    // consume sink contents
+    // The sink receives the decoded string followed by a '\0' terminator;
+    // length excludes the terminator.
+    template <typename T, typename V = void>
+    struct HandlerHasChunkedString : internal::FalseType {};
+    template <typename T>
+    struct HandlerHasChunkedString<T, typename internal::Void<typename T::ChunkedStringSinkType>::Type> : internal::TrueType {};
+
+    // Returns true if the string value was routed to the handler's sink
+    // (possibly with a parse error set); false to fall back to the stack.
+    template<unsigned parseFlags, typename InputStream, typename Handler>
+    bool ParseStringToChunkedSink(InputStream& s, Handler& handler, internal::TrueType) {
+        if (!handler.AcceptsChunkedString())
+            return false;
+        typename Handler::ChunkedStringSinkType& sink = handler.ChunkedStringSink();
+        ParseStringToStream<parseFlags, SourceEncoding, TargetEncoding>(s, sink);
+        RAPIDJSON_PARSE_ERROR_EARLY_RETURN(true);
+        SizeType length = static_cast<SizeType>(sink.GetLength()) - 1;
+        if (RAPIDJSON_UNLIKELY(!handler.ChunkedString(length)))
+            RAPIDJSON_PARSE_ERROR_NORETURN(kParseErrorTermination, s.Tell());
+        return true;
+    }
+
+    template<unsigned parseFlags, typename InputStream, typename Handler>
+    RAPIDJSON_FORCEINLINE bool ParseStringToChunkedSink(InputStream&, Handler&, internal::FalseType) {
+        return false;
+    }
+
     // Parse string and generate String event. Different code paths for kParseInsituFlag.
     template<unsigned parseFlags, typename InputStream, typename Handler>
     void ParseString(InputStream& is, Handler& handler, bool isKey = false) {
@@ -972,6 +1007,10 @@ private:
             RAPIDJSON_ASSERT(length <= 0xFFFFFFFF);
             const typename TargetEncoding::Ch* const str = reinterpret_cast<typename TargetEncoding::Ch*>(head);
             success = (isKey ? handler.Key(str, SizeType(length), false) : handler.String(str, SizeType(length), false));
+        }
+        else if (!isKey && ParseStringToChunkedSink<parseFlags>(s, handler, HandlerHasChunkedString<Handler>())) {
+            RAPIDJSON_PARSE_ERROR_EARLY_RETURN_VOID;
+            success = true;
         }
         else {
             StackStream<typename TargetEncoding::Ch> stackStream(stack_);

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -18,8 +18,10 @@
 #include "rapidjson/internal/dtoa.h"
 #include "rapidjson/internal/itoa.h"
 #include "rapidjson/memorystream.h"
+#include "rapidjson/stringbuffer.h"
 
 #include <limits>
+#include <vector>
 
 using namespace rapidjson;
 
@@ -893,6 +895,155 @@ TEST(Reader, ParseString_NonDestructive) {
     reader.Parse(s, h);
     EXPECT_EQ(0, StrCmp("Hello\nWorld", h.str_));
     EXPECT_EQ(11u, h.length_);
+}
+
+template <typename Encoding>
+struct ChunkedStringHandler : BaseReaderHandler<Encoding, ChunkedStringHandler<Encoding> > {
+    typedef typename Encoding::Ch Ch;
+    typedef GenericStringBuffer<Encoding> ChunkedStringSinkType;
+
+    ChunkedStringHandler() : sink_(), chunked_(), accepts_(true), chunkedReturn_(true), chunkedCount_(0), stringCount_(0), keyCount_(0) {}
+
+    ChunkedStringHandler(const ChunkedStringHandler&);
+    ChunkedStringHandler& operator=(const ChunkedStringHandler&);
+
+    bool AcceptsChunkedString() const { return accepts_; }
+    ChunkedStringSinkType& ChunkedStringSink() {
+        sink_.Clear();
+        return sink_;
+    }
+    bool ChunkedString(SizeType length) {
+        // The sink receives the decoded string plus a '\0' terminator;
+        // length excludes the terminator.
+        EXPECT_EQ(static_cast<size_t>(length) + 1, sink_.GetLength());
+        EXPECT_EQ(Ch('\0'), sink_.GetString()[length]);
+        chunked_.assign(sink_.GetString(), sink_.GetString() + length);
+        chunkedCount_++;
+        return chunkedReturn_;
+    }
+
+    bool String(const Ch*, SizeType, bool) { stringCount_++; return true; }
+    bool Key(const Ch*, SizeType, bool) { keyCount_++; return true; }
+    bool Default() { return true; }
+
+    ChunkedStringSinkType sink_;
+    std::vector<Ch> chunked_;
+    bool accepts_;
+    bool chunkedReturn_;
+    unsigned chunkedCount_;
+    unsigned stringCount_;
+    unsigned keyCount_;
+};
+
+template <typename Encoding>
+static void TestChunkedString(const typename Encoding::Ch* e, const typename Encoding::Ch* x) {
+    GenericStringStream<Encoding> s(x);
+    ChunkedStringHandler<Encoding> h;
+    GenericReader<Encoding, Encoding> reader;
+    reader.Parse(s, h);
+    EXPECT_FALSE(reader.HasParseError());
+    EXPECT_EQ(1u, h.chunkedCount_);
+    EXPECT_EQ(0u, h.stringCount_);
+    EXPECT_EQ(StrLen(e), h.chunked_.size());
+    EXPECT_TRUE(h.chunked_.empty() || memcmp(e, &h.chunked_[0], h.chunked_.size() * sizeof(typename Encoding::Ch)) == 0);
+}
+
+TEST(Reader, ParseString_ChunkedSink) {
+    // String values are decoded into the handler-provided sink and delivered
+    // via ChunkedString(); String() is not called.
+    TestChunkedString<UTF8<> >("", "\"\"");
+    TestChunkedString<UTF8<> >("Hello", "\"Hello\"");
+    TestChunkedString<UTF8<> >("Hello\nWorld", "\"Hello\\nWorld\"");
+    TestChunkedString<UTF8<> >("\"\\/\b\f\n\r\t", "\"\\\"\\\\/\\b\\f\\n\\r\\t\"");
+    TestChunkedString<UTF8<> >("\x24", "\"\\u0024\"");         // Dollar sign U+0024
+    TestChunkedString<UTF8<> >("\xC2\xA2", "\"\\u00A2\"");     // Cents sign U+00A2
+    TestChunkedString<UTF8<> >("\xE2\x82\xAC", "\"\\u20AC\""); // Euro sign U+20AC
+    TestChunkedString<UTF8<> >("\xF0\x9D\x84\x9E", "\"\\uD834\\uDD1E\"");  // G clef sign U+1D11E
+
+    // Support of null character in string
+    {
+        StringStream s("\"Hello\\u0000World\"");
+        ChunkedStringHandler<UTF8<> > h;
+        Reader reader;
+        reader.Parse(s, h);
+        EXPECT_FALSE(reader.HasParseError());
+        EXPECT_EQ(11u, h.chunked_.size());
+        EXPECT_EQ(0, memcmp("Hello\0World", &h.chunked_[0], 11));
+    }
+}
+
+TEST(Reader, ParseString_ChunkedSink_KeysUseStack) {
+    StringStream s("{\"key\":\"value\"}");
+    ChunkedStringHandler<UTF8<> > h;
+    Reader reader;
+    reader.Parse(s, h);
+    EXPECT_FALSE(reader.HasParseError());
+    EXPECT_EQ(1u, h.keyCount_);
+    EXPECT_EQ(1u, h.chunkedCount_);
+    EXPECT_EQ(0u, h.stringCount_);
+}
+
+TEST(Reader, ParseString_ChunkedSink_DynamicOptOut) {
+    StringStream s("\"Hello\"");
+    ChunkedStringHandler<UTF8<> > h;
+    h.accepts_ = false;
+    Reader reader;
+    reader.Parse(s, h);
+    EXPECT_FALSE(reader.HasParseError());
+    EXPECT_EQ(0u, h.chunkedCount_);
+    EXPECT_EQ(1u, h.stringCount_);
+}
+
+TEST(Reader, ParseString_ChunkedSink_Termination) {
+    StringStream s("\"Hello\"");
+    ChunkedStringHandler<UTF8<> > h;
+    h.chunkedReturn_ = false;
+    Reader reader;
+    reader.Parse(s, h);
+    EXPECT_TRUE(reader.HasParseError());
+    EXPECT_EQ(kParseErrorTermination, reader.GetParseErrorCode());
+}
+
+TEST(Reader, ParseString_ChunkedSink_Error) {
+    StringStream s("\"\\q\"");
+    ChunkedStringHandler<UTF8<> > h;
+    Reader reader;
+    reader.Parse(s, h);
+    EXPECT_TRUE(reader.HasParseError());
+    EXPECT_EQ(kParseErrorStringEscapeInvalid, reader.GetParseErrorCode());
+    EXPECT_EQ(0u, h.chunkedCount_);
+}
+
+TEST(Reader, ParseString_ChunkedSink_Transcoding) {
+    GenericStringStream<UTF8<> > is("\"Hello\"");
+    GenericReader<UTF8<>, UTF16<> > reader;
+    ChunkedStringHandler<UTF16<> > h;
+    reader.Parse(is, h);
+    EXPECT_FALSE(reader.HasParseError());
+    EXPECT_EQ(1u, h.chunkedCount_);
+    EXPECT_EQ(StrLen(L"Hello"), h.chunked_.size());
+    EXPECT_EQ(0, memcmp(L"Hello", &h.chunked_[0], 5 * sizeof(UTF16<>::Ch)));
+}
+
+TEST(Reader, ParseString_ChunkedSink_InsituTakesPrecedence) {
+    char buffer[] = "\"Hello\\nWorld\"";
+    InsituStringStream s(buffer);
+    ChunkedStringHandler<UTF8<> > h;
+    Reader reader;
+    reader.Parse<kParseInsituFlag>(s, h);
+    EXPECT_FALSE(reader.HasParseError());
+    EXPECT_EQ(0u, h.chunkedCount_);
+    EXPECT_EQ(1u, h.stringCount_);
+}
+
+TEST(Reader, ParseString_ChunkedSink_IterativeParsing) {
+    StringStream s("[\"Hello\\nWorld\"]");
+    ChunkedStringHandler<UTF8<> > h;
+    Reader reader;
+    reader.Parse<kParseIterativeFlag>(s, h);
+    EXPECT_FALSE(reader.HasParseError());
+    EXPECT_EQ(1u, h.chunkedCount_);
+    EXPECT_EQ(0u, h.stringCount_);
 }
 
 template <typename Encoding>


### PR DESCRIPTION
`GenericReader::ParseString()` buffers each decoded string value in the reader's internal `Stack`, a contiguous buffer grown via `Realloc`, before invoking `Handler::String()`. For very large string values (e.g. multi-MB JSON payloads) this forces a large contiguous allocation, which can fail under allocators that cannot serve large contiguous spans.

Allow a handler to opt in to receiving string values through a handler-provided output stream instead. An opting-in handler declares:

```
  using ChunkedStringSinkType = ...;           // Put(Ch), GetLength()
  bool AcceptsChunkedString() const;           // per-value opt-in
  ChunkedStringSinkType& ChunkedStringSink();  // returns an empty sink
  bool ChunkedString(::json::SizeType length); // consume sink contents
```